### PR TITLE
`configure` now uses `express.Router` instead of `expres.Express` as the type for `app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The `MetadataTransformer` type is defined in [`src/data.ts`](./src/data.ts) as:
 export type MetadataTransformer = (
   contractAddress: string,
   tokenID: string,
-  baseMetadata?: ERC721Metadata
+  baseMetadata?: ERC721Metadata,
 ) => Promise<ERC721Metadata>;
 ```
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/node": "^20.4.6",
     "@types/uuid": "^9.0.3",
     "@types/web3": "^1.2.2",
+    "prettier": "^3.0.3",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metadata-transformer",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The Metadata Transformer",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/data.ts
+++ b/src/data.ts
@@ -23,7 +23,7 @@ export interface Attribute {
 export type MetadataTransformer = (
   contractAddress: string,
   tokenID: string,
-  baseMetadata?: ERC721Metadata
+  baseMetadata?: ERC721Metadata,
 ) => Promise<ERC721Metadata>;
 
 // Chains together multiple transformers one after another, in the order specified.
@@ -33,7 +33,7 @@ export function chain(
   return async function (
     contractAddress: string,
     tokenID: string,
-    baseMetadata?: ERC721Metadata
+    baseMetadata?: ERC721Metadata,
   ): Promise<ERC721Metadata> {
     let result: ERC721Metadata = baseMetadata || {
       name: "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export default function configure(
         console.error(e);
         return res.status(500).json({ error: e });
       }
-    }
+    },
   );
 
   app.get(
@@ -53,6 +53,6 @@ export default function configure(
         console.error(e);
         return res.status(500).json({ error: e });
       }
-    }
+    },
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-import express, { Express, Request, Response } from "express";
+import { Router, Request, Response } from "express";
 import { chain, MetadataTransformer } from "./data";
 
 // Configures an express.js app with Metadata Transformer endpoints.
 // Uses the given status handler and transformers.
 // This mutates the app that it is passed, which is why it has no return.
 export default function configure(
-  app: Express,
+  app: Router,
   currentStatus: () => Promise<object>,
   ...transformers: MetadataTransformer[]
 ) {

--- a/src/middleware/logging.ts
+++ b/src/middleware/logging.ts
@@ -10,7 +10,7 @@ export function simpleLogger(req: Request, res: Response, next: NextFunction) {
   console.log(
     `Request: ${internalRequestTraceID} -- Initiated -- time: ${requestTime.toISOString()}, method: ${
       req.method
-    }, url: ${req.url}`
+    }, url: ${req.url}`,
   );
   // These gymnastics are necessary because express middleware `next` functions do not return promises.
   const originalSend = res.send.bind(res);
@@ -23,7 +23,7 @@ export function simpleLogger(req: Request, res: Response, next: NextFunction) {
         req.method
       }, url: ${req.url}, status: ${
         res.statusCode
-      }, duration: ${responseDuration} ms`
+      }, duration: ${responseDuration} ms`,
     );
 
     return originalSend(body);

--- a/src/middleware/redisCache.ts
+++ b/src/middleware/redisCache.ts
@@ -12,7 +12,7 @@ export function cacheOptionsFromEnv(): MetadataTransformerCacheOptions {
   const ttlMillisecondsRaw = process.env.METADATA_TRANSFORMER_CACHE_TTL_MILLIS;
   if (!ttlMillisecondsRaw) {
     throw new Error(
-      "Please set the METADATA_TRANSFORMER_CACHE_TTL_MILLIS environment variable"
+      "Please set the METADATA_TRANSFORMER_CACHE_TTL_MILLIS environment variable",
     );
   }
 
@@ -21,7 +21,7 @@ export function cacheOptionsFromEnv(): MetadataTransformerCacheOptions {
     ttlMilliseconds = parseInt(ttlMillisecondsRaw);
   } catch {
     throw new Error(
-      `Could not parse METADATA_TRANSFORMER_CACHE_TTL_MILLIS environment variable as an integer: ${ttlMillisecondsRaw}`
+      `Could not parse METADATA_TRANSFORMER_CACHE_TTL_MILLIS environment variable as an integer: ${ttlMillisecondsRaw}`,
     );
   }
 
@@ -34,7 +34,7 @@ export function cacheOptionsFromEnv(): MetadataTransformerCacheOptions {
 
 export function redisCachingMiddleware(
   cacheArgs: MetadataTransformerCacheOptions,
-  cache: ReturnType<typeof createClient>
+  cache: ReturnType<typeof createClient>,
 ) {
   return async (req: Request, res: Response, next: NextFunction) => {
     const requestTime = new Date();
@@ -57,14 +57,14 @@ export function redisCachingMiddleware(
       console.log(
         `${tracingPrefix}Cache hit -- url: ${
           req.url
-        }, time: ${requestTime.toISOString()}`
+        }, time: ${requestTime.toISOString()}`,
       );
       res.send(cachedMetadata);
     } else {
       console.log(
         `${tracingPrefix}Cache miss -- url: ${
           req.url
-        }, time: ${requestTime.toISOString()}`
+        }, time: ${requestTime.toISOString()}`,
       );
       const originalSend = res.send.bind(res);
       const wrappedSend = (body: any): Response<any> => {

--- a/src/servers/polygonInventories.ts
+++ b/src/servers/polygonInventories.ts
@@ -20,7 +20,7 @@ if (!!USE_REDIS && USE_REDIS !== "false") {
   const cacheOptions = cacheOptionsFromEnv();
   if (cacheOptions.ttlMilliseconds > 0) {
     console.info(
-      `Loading Redis cache middleware -- METADATA_TRANSFORMER_CACHE_TTL_MILLIS: ${cacheOptions.ttlMilliseconds}, METADATA_TRANSFORMER_CACHE_TRACING: ${cacheOptions.tracing}`
+      `Loading Redis cache middleware -- METADATA_TRANSFORMER_CACHE_TTL_MILLIS: ${cacheOptions.ttlMilliseconds}, METADATA_TRANSFORMER_CACHE_TRACING: ${cacheOptions.tracing}`,
     );
 
     const cache = createClient();
@@ -38,5 +38,5 @@ run(
   createInventoryTransformer(web3, {
     "0xC740674d2DafF5e59284Fc10a39C862A53BF627D":
       "0x96f47A4FBBFE506e2EFC60a04E37dE82A8564e8C",
-  })
+  }),
 );

--- a/src/servers/run.ts
+++ b/src/servers/run.ts
@@ -16,7 +16,7 @@ if (!WEB3_PROVIDER_URI) {
   throw new Error("Please set the METADATA_TRANSFORMER_WEB3_PROVIDER_URI");
 }
 export const web3 = new Web3(
-  new Web3.providers.HttpProvider(WEB3_PROVIDER_URI)
+  new Web3.providers.HttpProvider(WEB3_PROVIDER_URI),
 );
 
 async function serverStatus(): Promise<object> {

--- a/src/transformers/fresh.ts
+++ b/src/transformers/fresh.ts
@@ -4,7 +4,7 @@ import { ERC721Metadata } from "../data";
 export default async function fresh(
   contractAddress: string,
   tokenID: string,
-  baseMetadata?: ERC721Metadata
+  baseMetadata?: ERC721Metadata,
 ): Promise<ERC721Metadata> {
   return {
     name: "",

--- a/src/transformers/inventory.ts
+++ b/src/transformers/inventory.ts
@@ -10,7 +10,7 @@ import { ERC721Metadata, MetadataTransformer } from "../data";
 export function createInventoryTransformer(
   web3: Web3,
   inventories: Record<string, string>,
-  multicallAddress?: string
+  multicallAddress?: string,
 ): MetadataTransformer {
   // Normalization of keys (and values)
   for (let contractAddress in inventories) {
@@ -21,14 +21,14 @@ export function createInventoryTransformer(
   // TODO(zomglings): Implement multicall logic if multicallAddress is defined.
   if (multicallAddress) {
     console.warn(
-      "This transformer does not currently support Multicall functionality."
+      "This transformer does not currently support Multicall functionality.",
     );
   }
 
   return async function inventoryTransformer(
     contractAddress: string,
     tokenID: string,
-    baseMetadata?: ERC721Metadata
+    baseMetadata?: ERC721Metadata,
   ): Promise<ERC721Metadata> {
     const result: ERC721Metadata = baseMetadata || {
       name: "",
@@ -46,7 +46,7 @@ export function createInventoryTransformer(
     if (inventoryContractAddress) {
       const inventory = new web3.eth.Contract(
         INVENTORY_ABI,
-        inventoryContractAddress
+        inventoryContractAddress,
       );
       const numSlots: bigint = await inventory.methods.numSlots().call();
       for (let slot = 0; slot < numSlots; slot++) {

--- a/src/transformers/tokenURI.ts
+++ b/src/transformers/tokenURI.ts
@@ -36,7 +36,7 @@ export function createTokenURITransformer(web3: Web3): MetadataTransformer {
   async function tokenURI(
     contractAddress: string,
     tokenID: string,
-    baseMetadata?: ERC721Metadata
+    baseMetadata?: ERC721Metadata,
   ): Promise<ERC721Metadata> {
     const erc721Contract = new web3.eth.Contract(TOKENURI_ABI, contractAddress);
     // @ts-ignore -- Typescript doesn't understand the variadic arguments to myContract.methods.myMethod.
@@ -69,7 +69,7 @@ export function createTokenURITransformer(web3: Web3): MetadataTransformer {
       }
     } catch (err) {
       console.error(
-        `Error parsing metadata for contractAddress=${contractAddress}, tokenID=${tokenID}: ${err}`
+        `Error parsing metadata for contractAddress=${contractAddress}, tokenID=${tokenID}: ${err}`,
       );
     }
     return result;


### PR DESCRIPTION
This allows a single server to host multiple routes corresponding to different blockchains.